### PR TITLE
Bumps everything in CefGlue to .NET 6

### DIFF
--- a/CefGlue.Client/CefGlue.Client.csproj
+++ b/CefGlue.Client/CefGlue.Client.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net5.0-windows</TargetFramework>
+    <TargetFramework>net6.0-windows</TargetFramework>
 
     <OutputType>WinExe</OutputType>
     <RootNamespace>Xilium.CefGlue.Client</RootNamespace>

--- a/CefGlue.Demo.WinForms/CefGlue.Demo.WinForms.csproj
+++ b/CefGlue.Demo.WinForms/CefGlue.Demo.WinForms.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net5.0-windows</TargetFramework>
+    <TargetFramework>net6.0-windows</TargetFramework>
 
     <OutputType>WinExe</OutputType>
     <AssemblyName>Xilium.CefGlue.Demo.WinForms</AssemblyName>

--- a/CefGlue.Demo/CefGlue.Demo.csproj
+++ b/CefGlue.Demo/CefGlue.Demo.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net5.0</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
 
     <RootNamespace>Xilium.CefGlue.Demo</RootNamespace>
     <AssemblyName>Xilium.CefGlue.Demo</AssemblyName>

--- a/CefGlue.Samples.WpfOsr/CefGlue.Samples.WpfOsr.csproj
+++ b/CefGlue.Samples.WpfOsr/CefGlue.Samples.WpfOsr.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net5.0-windows</TargetFramework>
+    <TargetFramework>net6.0-windows</TargetFramework>
 
     <OutputType>WinExe</OutputType>
     <AssemblyName>Xilium.Samples.WpfOsr</AssemblyName>

--- a/CefGlue.WPF/CefGlue.WPF.csproj
+++ b/CefGlue.WPF/CefGlue.WPF.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net5.0-windows</TargetFramework>
+    <TargetFramework>net6.0-windows</TargetFramework>
 
     <AssemblyName>Xilium.CefGlue.WPF</AssemblyName>
     <RootNamespace>Xilium.CefGlue.WPF</RootNamespace>

--- a/CefGlue.WindowsForms/CefGlue.WindowsForms.csproj
+++ b/CefGlue.WindowsForms/CefGlue.WindowsForms.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net5.0-windows</TargetFramework>
+    <TargetFramework>net6.0-windows</TargetFramework>
 
     <AssemblyName>Xilium.CefGlue.WindowsForms</AssemblyName>
     <RootNamespace>Xilium.CefGlue.WindowsForms</RootNamespace>

--- a/CefGlue/CefGlue.csproj
+++ b/CefGlue/CefGlue.csproj
@@ -1,7 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.0;net45</TargetFrameworks>
 
     <AssemblyName>Xilium.CefGlue</AssemblyName>
     <RootNamespace>Xilium.CefGlue</RootNamespace>
@@ -11,6 +10,7 @@
 
     <Version>95.7.14</Version>
     <IsPackable>true</IsPackable>
+    <TargetFramework>net6.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
wixoa can't compile in VS 2022 because it doesn't support .NET Framework 4.5 anymore, so I went and bumped every target framework to .NET 6

Tested it with the cefglue demo and it seems fine.