### PR TITLE
Disable `CS1591` warnings

### DIFF
--- a/CefGlue/CefGlue.csproj
+++ b/CefGlue/CefGlue.csproj
@@ -11,6 +11,8 @@
 
     <Version>120.1.9</Version>
     <IsPackable>true</IsPackable>
+
+    <NoWarn>CS1591</NoWarn>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Compiling OpenDream be like:

![image](https://github.com/user-attachments/assets/4c46b63e-8905-4f74-93ac-e4fed689c562)
